### PR TITLE
Ship Habits Phase 3: first habit achievement and unlock feedback

### DIFF
--- a/backend/dailyflo/apps/gamification/fixtures/achievements.json
+++ b/backend/dailyflo/apps/gamification/fixtures/achievements.json
@@ -118,5 +118,17 @@
       "sort_order": 10,
       "criteria": {"type": "first_goal_met"}
     }
+  },
+  {
+    "model": "gamification.achievementdefinition",
+    "pk": "a1000000-0000-4000-8000-000000000011",
+    "fields": {
+      "code": "first_habit_completion",
+      "title": "First habit",
+      "description": "Complete your first habit.",
+      "icon_key": "repeat.circle.fill",
+      "sort_order": 11,
+      "criteria": {"type": "habit_completion_count", "min": 1}
+    }
   }
 ]

--- a/backend/dailyflo/apps/gamification/services/achievements.py
+++ b/backend/dailyflo/apps/gamification/services/achievements.py
@@ -10,8 +10,20 @@ from apps.gamification.models import AchievementDefinition, UserAchievement
 from apps.gamification.services.stats import _current_streak, _longest_streak, _week_start, effective_completion_date, get_user_timezone
 
 
-def _lifetime_completion_count(logs) -> int:
-    return logs.count() if hasattr(logs, 'count') else len(list(logs))
+def _count_logs(logs) -> int:
+    return logs.count() if hasattr(logs, 'count') else len(logs)
+
+
+def _logs_with_action(logs, action_type: str):
+    """filter activity logs by action_type — works on queryset or materialized list."""
+    if hasattr(logs, 'filter'):
+        return logs.filter(action_type=action_type)
+    return [log for log in logs if getattr(log, 'action_type', None) == action_type]
+
+
+def _lifetime_completion_count(logs, action_type: str = 'completed') -> int:
+    """count completion events — task achievements use 'completed'; habits use 'habit_completed'."""
+    return _count_logs(_logs_with_action(logs, action_type))
 
 
 def _criteria_met(criteria: dict, user, completion_dates: set, logs) -> bool:
@@ -29,13 +41,21 @@ def _criteria_met(criteria: dict, user, completion_dates: set, logs) -> bool:
     if ctype == 'completion_count':
         period = criteria.get('period', 'all_time')
         min_count = criteria.get('min', 1)
+        task_logs = _logs_with_action(logs, 'completed')
         if period == 'all_time':
-            return _lifetime_completion_count(logs) >= min_count
+            return _count_logs(task_logs) >= min_count
         if period == 'week':
             week_start = _week_start(today)
-            count = sum(1 for log in logs if effective_completion_date(log, user_tz) >= week_start)
+            count = sum(
+                1 for log in task_logs
+                if effective_completion_date(log, user_tz) >= week_start
+            )
             return count >= min_count
         return False
+
+    if ctype == 'habit_completion_count':
+        min_count = criteria.get('min', 1)
+        return _lifetime_completion_count(logs, 'habit_completed') >= min_count
 
     if ctype == 'perfect_week':
         week_start = _week_start(today)
@@ -97,7 +117,11 @@ def _progress_hint(criteria, user, completion_dates, logs, today, user_tz):
         return f'{min(current, target)}/{target} days'
     if criteria.get('type') == 'completion_count' and criteria.get('period') == 'all_time':
         target = criteria.get('min', 1)
-        current = _lifetime_completion_count(logs)
+        current = _lifetime_completion_count(logs, 'completed')
+        return f'{min(current, target)}/{target}'
+    if criteria.get('type') == 'habit_completion_count':
+        target = criteria.get('min', 1)
+        current = _lifetime_completion_count(logs, 'habit_completed')
         return f'{min(current, target)}/{target}'
     return None
 

--- a/backend/dailyflo/apps/gamification/services/stats.py
+++ b/backend/dailyflo/apps/gamification/services/stats.py
@@ -88,7 +88,7 @@ def compute_gamification_summary(user):
     logs = ActivityLog.objects.filter(
         user=user,
         action_type__in=['completed', 'habit_completed'],
-    ).only('occurrence_date', 'created_at', 'task_id')
+    ).only('occurrence_date', 'created_at', 'task_id', 'action_type')
 
     completion_dates: set[date] = set()
     completions_today = 0

--- a/docs/technical-design/habits/plan/habits-implementation.md
+++ b/docs/technical-design/habits/plan/habits-implementation.md
@@ -4,7 +4,7 @@
 
 **Audience:** Engineers working in `frontend/dailyflo` (Expo Router, Redux Toolkit) and `backend/dailyflo` (Django REST).
 
-**Status:** Draft — product decisions locked via planning Q&A (2026-06-07); **no habits backend or feature UI shipped yet** (Habits tab is placeholder shell only).
+**Status:** Phase 1–3 shipped on `feat/habits`; Phase 4 (local reminders) not started.
 
 **See also:**
 
@@ -473,9 +473,9 @@ Reuse [`notification-implementation.md`](../../notifications/plan/notification-i
 
 ### Phase 3 — Gamification polish
 
-- [ ] `HabitTabSummaryHeader` on Habits tab
-- [ ] `first_habit_completion` fixture + evaluator
-- [ ] Unlock feedback (reuse achievements screen patterns / light haptic)
+- [x] `HabitTabSummaryHeader` on Habits tab
+- [x] `first_habit_completion` fixture + evaluator
+- [x] Unlock feedback (reuse achievements screen patterns / light haptic)
 
 **Exit criteria:** First habit check-off unlocks achievement; tab summary reflects today’s progress.
 
@@ -560,3 +560,4 @@ Update [`back-log.md`](../../../development-journals/back-log.md) when Phase 1 s
 | Date | Change |
 | --- | --- |
 | 2026-06-07 | Initial draft from product Q&A feature mapping |
+| 2026-06-15 | Phase 3 gamification polish — `first_habit_completion` achievement + unlock banner |

--- a/docs/testing/habits-manual-testing.md
+++ b/docs/testing/habits-manual-testing.md
@@ -41,7 +41,7 @@ This guide is the step-by-step manual test plan for the **Habits** feature in Da
 | Delete habit | **Shipped** | From detail with confirm alert |
 | Onboarding → Habit | **Shipped** | No recurring onboarding task |
 | Global streak (ActivityLog) | **Shipped** | `habit_completed` rows feed gamification |
-| `first_habit_completion` achievement | **Not shipped** | Phase 3 — skip |
+| `first_habit_completion` achievement | **Shipped** | Unlocks on first habit complete; toast banner |
 | Local habit reminders | **Not shipped** | Phase 4 — skip |
 
 **Out of scope for v1 (do not expect):** quit/sobriety habits, Planner integration, `linked_habit` goals, push notifications.
@@ -515,17 +515,51 @@ curl -H "Authorization: Bearer TOKEN" http://localhost:8000/api/habits/HABIT_ID/
 
 ---
 
-## Phase 3 & 4 — skip until shipped
+## Phase 3 — gamification polish
+
+### Test 12 — `first_habit_completion` achievement
+
+**Precondition:** Fresh account (or account that has never completed a habit).
+
+1. Complete any habit for the first time (Habits tab or Today section).
+2. Observe unlock banner at top of screen (achievement title + success haptic).
+3. Open **Browse → Productivity → Achievements**.
+
+**Expected**
+
+- [ ] **First habit** achievement shows unlocked with checkmark seal.
+- [ ] Persists after app restart.
+- [ ] Completing a habit does **not** unlock **First step** (task-only) unless a task was also completed.
+
+| Pass | Fail | Notes |
+| --- | --- | --- |
+| ☐ | ☐ | |
+
+### Test 13 — Tab summary header
+
+1. Open **Habits** tab with at least one habit due today.
+2. Complete one habit; pull to refresh if needed.
+
+**Expected**
+
+- [ ] Header shows `completedCount/scheduledCount` for today.
+- [ ] Best active streak among today’s habits displayed when any streak &gt; 0.
+
+| Pass | Fail | Notes |
+| --- | --- | --- |
+| ☐ | ☐ | |
+
+---
+
+## Phase 4 — skip until shipped
 
 | Test | Phase | Status |
 | --- | --- | --- |
-| `first_habit_completion` achievement unlocks on first complete | 3 | Not implemented |
-| Habits tab achievement / unlock feedback UI | 3 | Not implemented |
 | Local notification at `reminder_time` when habit due | 4 | Not implemented |
 | Delete habit cancels scheduled notification | 4 | Not implemented |
 | Logout cancels all habit reminder notifications | 4 | Not implemented |
 
-Re-run these sections when Phase 3/4 land; see [`habits-implementation.md`](../technical-design/habits/plan/habits-implementation.md) §12–13.
+Re-run Phase 4 when reminders land; see [`habits-implementation.md`](../technical-design/habits/plan/habits-implementation.md) §10–13.
 
 ---
 

--- a/frontend/dailyflo/app/(tabs)/_layout.tsx
+++ b/frontend/dailyflo/app/(tabs)/_layout.tsx
@@ -20,6 +20,7 @@ import { getTodayTabIcon } from '@/utils/todayIcon';
 import { CustomLiquidTabBar, USE_CUSTOM_LIQUID_TAB_BAR } from '@/components/navigation/tabBarChrome';
 import { TabFabOverlayLayer } from '@/components/navigation/tabBarChrome/TabFabOverlayLayer';
 import { TabFabOverlayProvider } from '@/contexts/TabFabOverlayContext';
+import { AchievementUnlockBanner } from '@/components/features/gamification/achievements/AchievementUnlockBanner';
 import { usePrimaryTabColdStartNavigation } from '@/hooks/usePrimaryTabColdStartNavigation';
 
 export default function TabLayout() {
@@ -192,6 +193,7 @@ export default function TabLayout() {
             bootOverlayAnimatedStyle,
           ]}
         />
+        <AchievementUnlockBanner />
       </View>
     </TabFabOverlayProvider>
   );

--- a/frontend/dailyflo/components/features/gamification/achievements/AchievementUnlockBanner.tsx
+++ b/frontend/dailyflo/components/features/gamification/achievements/AchievementUnlockBanner.tsx
@@ -1,0 +1,175 @@
+/**
+ * achievement unlock toast — slides in after a habit completion unlocks a trophy.
+ * reads pending unlock from redux gamification slice; auto-dismisses after a few seconds.
+ */
+
+import React, { useEffect, useMemo, useRef } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as Haptics from 'expo-haptics';
+
+import { SFSymbolIcon } from '@/components/ui/Icon';
+import { Paddings } from '@/constants/Paddings';
+import { useBrandColors, useThemeColors } from '@/hooks/useColorPalette';
+import { useTypography } from '@/hooks/useTypography';
+import { useAppDispatch, useAppSelector } from '@/store';
+import { clearPendingAchievementUnlock } from '@/store/slices/gamification/gamificationSlice';
+
+const AUTO_DISMISS_MS = 4500;
+
+export function AchievementUnlockBanner() {
+  const dispatch = useAppDispatch();
+  const insets = useSafeAreaInsets();
+  const themeColors = useThemeColors();
+  const typography = useTypography();
+  const { getMarpleBrandColor } = useBrandColors();
+  const pendingUnlock = useAppSelector((state) => state.gamification.pendingAchievementUnlock);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const translateY = useSharedValue(-120);
+  const opacity = useSharedValue(0);
+
+  const styles = useMemo(
+    () => createStyles(themeColors, typography, getMarpleBrandColor(500), insets.top),
+    [themeColors, typography, getMarpleBrandColor, insets.top],
+  );
+
+  const dismiss = () => {
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+    }
+    opacity.value = withTiming(0, { duration: 180 });
+    translateY.value = withTiming(-120, { duration: 220 }, (finished) => {
+      if (finished) {
+        runOnJS(dispatch)(clearPendingAchievementUnlock());
+      }
+    });
+  };
+
+  useEffect(() => {
+    if (!pendingUnlock) {
+      translateY.value = -120;
+      opacity.value = 0;
+      return;
+    }
+
+    // success haptic when a new trophy unlocks from habit progress
+    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+
+    translateY.value = withSpring(0, { damping: 18, stiffness: 220 });
+    opacity.value = withTiming(1, { duration: 200 });
+
+    dismissTimerRef.current = setTimeout(() => {
+      dismiss();
+    }, AUTO_DISMISS_MS);
+
+    return () => {
+      if (dismissTimerRef.current) {
+        clearTimeout(dismissTimerRef.current);
+        dismissTimerRef.current = null;
+      }
+    };
+  }, [pendingUnlock?.id]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+    opacity: opacity.value,
+  }));
+
+  if (!pendingUnlock) return null;
+
+  return (
+    <Animated.View pointerEvents="box-none" style={[styles.host, animatedStyle]}>
+      <Pressable
+        onPress={dismiss}
+        style={styles.card}
+        accessibilityRole="alert"
+        accessibilityLabel={`Achievement unlocked: ${pendingUnlock.title}`}
+      >
+        <View style={styles.iconWrap}>
+          <SFSymbolIcon
+            name={pendingUnlock.iconKey as any}
+            size={28}
+            color={getMarpleBrandColor(500)}
+          />
+        </View>
+        <View style={styles.textWrap}>
+          <Text style={styles.eyebrow}>Achievement unlocked</Text>
+          <Text style={styles.title} numberOfLines={1}>
+            {pendingUnlock.title}
+          </Text>
+          <Text style={styles.description} numberOfLines={2}>
+            {pendingUnlock.description}
+          </Text>
+        </View>
+        <SFSymbolIcon name="checkmark.seal.fill" size={22} color={getMarpleBrandColor(500)} />
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+const createStyles = (
+  themeColors: ReturnType<typeof useThemeColors>,
+  typography: ReturnType<typeof useTypography>,
+  brandColor: string,
+  safeTop: number,
+) =>
+  StyleSheet.create({
+    host: {
+      position: 'absolute',
+      top: safeTop + 8,
+      left: Paddings.screen,
+      right: Paddings.screen,
+      zIndex: 200,
+    },
+    card: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: Paddings.groupedListIconTextSpacing,
+      padding: Paddings.groupedListContentHorizontal,
+      borderRadius: Paddings.formDataPillRadius,
+      backgroundColor: themeColors.background.primarySecondaryBlend(),
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: themeColors.withOpacity(brandColor, 0.35),
+      shadowColor: '#000',
+      shadowOpacity: 0.12,
+      shadowRadius: 12,
+      shadowOffset: { width: 0, height: 4 },
+      elevation: 6,
+    },
+    iconWrap: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: themeColors.withOpacity(brandColor, 0.12),
+    },
+    textWrap: {
+      flex: 1,
+      minWidth: 0,
+      gap: 2,
+    },
+    eyebrow: {
+      ...typography.getTextStyle('body-small'),
+      color: brandColor,
+      fontWeight: '600',
+    },
+    title: {
+      ...typography.getTextStyle('body-large'),
+      color: themeColors.text.primary(),
+      fontWeight: '600',
+    },
+    description: {
+      ...typography.getTextStyle('body-small'),
+      color: themeColors.text.secondary(),
+    },
+  });

--- a/frontend/dailyflo/components/features/habits/list/HabitListItem.tsx
+++ b/frontend/dailyflo/components/features/habits/list/HabitListItem.tsx
@@ -41,8 +41,9 @@ export function HabitListItem({ habit, compact = false, onOpenDetail }: HabitLis
   const handleBinaryPress = useCallback(() => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     snapshotRef.current = { ...habit };
+    const wasCompleteBefore = habit.isCompleteToday;
     dispatch(optimisticLogHabit({ id: habit.id }));
-    void dispatch(logHabitProgress({ id: habit.id }))
+    void dispatch(logHabitProgress({ id: habit.id, wasCompleteBefore }))
       .unwrap()
       .catch(() => {
         if (snapshotRef.current) {
@@ -55,8 +56,9 @@ export function HabitListItem({ habit, compact = false, onOpenDetail }: HabitLis
     if (habit.isCompleteToday) return;
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     snapshotRef.current = { ...habit };
+    const wasCompleteBefore = habit.isCompleteToday;
     dispatch(optimisticLogHabit({ id: habit.id, delta: 1 }));
-    void dispatch(logHabitProgress({ id: habit.id, delta: 1 }))
+    void dispatch(logHabitProgress({ id: habit.id, delta: 1, wasCompleteBefore }))
       .unwrap()
       .catch(() => {
         if (snapshotRef.current) {

--- a/frontend/dailyflo/store/slices/gamification/gamificationSlice.ts
+++ b/frontend/dailyflo/store/slices/gamification/gamificationSlice.ts
@@ -18,6 +18,8 @@ interface GamificationState {
   summary: GamificationSummary | null;
   achievements: AchievementItem[];
   goals: UserGoalItem[];
+  /** set when a habit log unlocks a new achievement — drives AchievementUnlockBanner */
+  pendingAchievementUnlock: AchievementItem | null;
   isSummaryLoading: boolean;
   isAchievementsLoading: boolean;
   isGoalsLoading: boolean;
@@ -44,6 +46,7 @@ const initialState: GamificationState = {
   summary: null,
   achievements: [],
   goals: [],
+  pendingAchievementUnlock: null,
   isSummaryLoading: false,
   isAchievementsLoading: false,
   isGoalsLoading: false,
@@ -127,6 +130,7 @@ const gamificationSlice = createSlice({
       state.summary = null;
       state.achievements = [];
       state.goals = [];
+      state.pendingAchievementUnlock = null;
       state.summaryError = null;
       state.achievementsError = null;
       state.goalsError = null;
@@ -137,6 +141,13 @@ const gamificationSlice = createSlice({
       state.achievementsError = null;
       state.goalsError = null;
       state.goalSaveError = null;
+    },
+    /** show unlock toast after habit completion — cleared when banner dismisses */
+    setPendingAchievementUnlock: (state, action: PayloadAction<AchievementItem>) => {
+      state.pendingAchievementUnlock = action.payload;
+    },
+    clearPendingAchievementUnlock: (state) => {
+      state.pendingAchievementUnlock = null;
     },
   },
   extraReducers: (builder) => {
@@ -195,6 +206,6 @@ const gamificationSlice = createSlice({
   },
 });
 
-export const { clearGamification, clearGamificationErrors } = gamificationSlice.actions;
+export const { clearGamification, clearGamificationErrors, setPendingAchievementUnlock, clearPendingAchievementUnlock } = gamificationSlice.actions;
 export { emptySummary };
 export default gamificationSlice.reducer;

--- a/frontend/dailyflo/store/slices/habits/habitsSlice.ts
+++ b/frontend/dailyflo/store/slices/habits/habitsSlice.ts
@@ -133,18 +133,48 @@ export const fetchHabitStats = createAsyncThunk(
 export const logHabitProgress = createAsyncThunk(
   'habits/logProgress',
   async (
-    { id, date, delta }: { id: string; date?: string; delta?: number },
+    {
+      id,
+      date,
+      delta,
+      wasCompleteBefore,
+    }: { id: string; date?: string; delta?: number; wasCompleteBefore?: boolean },
     { rejectWithValue, dispatch, getState },
   ) => {
     try {
+      const stateBefore = getState() as {
+        gamification: { achievements: { code: string; unlockedAt: string | null }[] };
+      };
+      const priorUnlockedCodes = new Set(
+        stateBefore.gamification.achievements
+          .filter((a) => a.unlockedAt != null)
+          .map((a) => a.code),
+      );
+
       const response = await habitsApiService.logHabitProgress(id, { date, delta });
-      const state = getState() as { habits: HabitsState };
-      const previous = state.habits.todayHabits.find((h) => h.id === id);
-      const wasComplete = previous?.isCompleteToday ?? false;
+      const wasComplete = wasCompleteBefore ?? false;
+
       if (response.isCompleteToday && !wasComplete) {
-        const { fetchGamificationSummary } = await import('../gamification/gamificationSlice');
-        void dispatch(fetchGamificationSummary());
+        const {
+          fetchGamificationSummary,
+          fetchAchievements,
+          setPendingAchievementUnlock,
+        } = await import('../gamification/gamificationSlice');
+
+        // summary re-runs achievement evaluator on django; achievements list returns unlock state
+        await dispatch(fetchGamificationSummary());
+        const achievementsResult = await dispatch(fetchAchievements());
+
+        if (fetchAchievements.fulfilled.match(achievementsResult)) {
+          const newlyUnlocked = achievementsResult.payload
+            .filter((a) => a.unlockedAt != null && !priorUnlockedCodes.has(a.code))
+            .sort((a, b) => a.sortOrder - b.sortOrder);
+          if (newlyUnlocked.length > 0) {
+            dispatch(setPendingAchievementUnlock(newlyUnlocked[0]));
+          }
+        }
       }
+
       const stateAfter = getState() as { habits: HabitsState };
       if (stateAfter.habits.detailHabit?.id === id) {
         void dispatch(fetchHabitStats(id));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Habits Implementation Phase 3 — Gamification polish** from `habits-implementation.md`.

Phase 3 exit criteria:
- First habit check-off unlocks a dedicated **`first_habit_completion`** achievement
- Tab summary reflects today's progress (already shipped in Phase 1/2 via `HabitTabSummaryHeader`)
- Unlock feedback appears when a new trophy is earned from habit logging

## What changed

### Backend
- Added `first_habit_completion` achievement fixture (`habit_completion_count` criteria)
- Extended achievement evaluator with `habit_completion_count` type
- Scoped existing `completion_count` achievements to **task** completions only (`action_type='completed'`) so completing a habit no longer unlocks "First step"

### Frontend
- New `AchievementUnlockBanner` toast (marple styling, success haptic, auto-dismiss)
- `logHabitProgress` now refreshes gamification summary + achievements and surfaces newly unlocked trophies
- Fixed pre-existing bug where gamification refresh never ran because `wasComplete` was read after optimistic Redux toggle — `HabitListItem` now passes `wasCompleteBefore`

### Docs
- Marked Phase 3 complete in implementation plan
- Added Phase 3 manual test scenarios in `habits-manual-testing.md`

## Deploy note

After merging, load the updated achievements fixture on environments that already have gamification data:

```bash
python manage.py loaddata achievements
```

## Manual QA

1. Use a fresh account (or one with zero habit completions)
2. Complete a habit on Habits tab or Today section
3. Confirm unlock banner appears + success haptic
4. Browse → Achievements → **First habit** is unlocked
5. Confirm **First step** (task achievement) is **not** unlocked unless a task was completed

## Next up

Phase 4 — local habit reminders (`habitReminderScheduler.ts`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a1b1f36-c298-445b-a97a-f038e6ed3846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a1b1f36-c298-445b-a97a-f038e6ed3846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

